### PR TITLE
Fix/refactor url service

### DIFF
--- a/src/main/java/edu/kpi/testcourse/auth/AuthorizationMockService.java
+++ b/src/main/java/edu/kpi/testcourse/auth/AuthorizationMockService.java
@@ -1,6 +1,6 @@
 package edu.kpi.testcourse.auth;
 
-import edu.kpi.testcourse.exception.UnauthorizedException;
+import edu.kpi.testcourse.exception.user.UnauthorizedException;
 
 /**
  * Mock service to provide user authorization by completely random JWT token.

--- a/src/main/java/edu/kpi/testcourse/auth/AuthorizationMockService.java
+++ b/src/main/java/edu/kpi/testcourse/auth/AuthorizationMockService.java
@@ -1,6 +1,6 @@
 package edu.kpi.testcourse.auth;
 
-import edu.kpi.testcourse.exception.user.UnauthorizedException;
+import edu.kpi.testcourse.exception.auth.UnauthorizedException;
 
 /**
  * Mock service to provide user authorization by completely random JWT token.

--- a/src/main/java/edu/kpi/testcourse/auth/AuthorizationMockServiceImpl.java
+++ b/src/main/java/edu/kpi/testcourse/auth/AuthorizationMockServiceImpl.java
@@ -1,6 +1,6 @@
 package edu.kpi.testcourse.auth;
 
-import edu.kpi.testcourse.exception.UnauthorizedException;
+import edu.kpi.testcourse.exception.user.UnauthorizedException;
 import java.util.HashMap;
 import javax.inject.Singleton;
 

--- a/src/main/java/edu/kpi/testcourse/auth/AuthorizationMockServiceImpl.java
+++ b/src/main/java/edu/kpi/testcourse/auth/AuthorizationMockServiceImpl.java
@@ -1,6 +1,6 @@
 package edu.kpi.testcourse.auth;
 
-import edu.kpi.testcourse.exception.user.UnauthorizedException;
+import edu.kpi.testcourse.exception.auth.UnauthorizedException;
 import java.util.HashMap;
 import javax.inject.Singleton;
 

--- a/src/main/java/edu/kpi/testcourse/bigtable/BigTableManager.java
+++ b/src/main/java/edu/kpi/testcourse/bigtable/BigTableManager.java
@@ -1,7 +1,7 @@
 package edu.kpi.testcourse.bigtable;
 
-import edu.kpi.testcourse.dto.User;
 import edu.kpi.testcourse.dto.ShortLink;
+import edu.kpi.testcourse.dto.User;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Optional;

--- a/src/main/java/edu/kpi/testcourse/bigtable/BigTableManager.java
+++ b/src/main/java/edu/kpi/testcourse/bigtable/BigTableManager.java
@@ -1,7 +1,7 @@
 package edu.kpi.testcourse.bigtable;
 
 import edu.kpi.testcourse.dto.User;
-import edu.kpi.testcourse.logic.ShortLinkMock;
+import edu.kpi.testcourse.dto.ShortLink;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Optional;
@@ -16,11 +16,11 @@ public interface BigTableManager {
 
   void storeUser(User user) throws IOException;
 
-  Optional<ShortLinkMock> findShortLink(String shortLink) throws IOException;
+  Optional<ShortLink> findShortLink(String shortLink) throws IOException;
 
   void deleteLink(String shortLink) throws IOException;
 
-  ArrayList<ShortLinkMock> listAllUserLinks(String email) throws IOException;
+  ArrayList<ShortLink> listAllUserLinks(String email) throws IOException;
 
-  void storeLink(ShortLinkMock link) throws IOException;
+  void storeLink(ShortLink link) throws IOException;
 }

--- a/src/main/java/edu/kpi/testcourse/bigtable/BigTableManagerImpl.java
+++ b/src/main/java/edu/kpi/testcourse/bigtable/BigTableManagerImpl.java
@@ -81,13 +81,13 @@ public class BigTableManagerImpl implements BigTableManager {
         return null;
       })
       .filter(Objects::nonNull)
-      .filter((s) -> s.userEmail().equals(email))
+      .filter((s) -> s.email().equals(email))
       .collect(Collectors.toCollection(ArrayList::new));
   }
 
   @Override
   public void storeLink(ShortLink link) throws IOException {
     String json = Main.getGson().toJson(link);
-    bigTable.store(link.shortLink(), json, DataFolder.Links);
+    bigTable.store(link.alias(), json, DataFolder.Links);
   }
 }

--- a/src/main/java/edu/kpi/testcourse/bigtable/BigTableManagerImpl.java
+++ b/src/main/java/edu/kpi/testcourse/bigtable/BigTableManagerImpl.java
@@ -1,8 +1,8 @@
 package edu.kpi.testcourse.bigtable;
 
 import edu.kpi.testcourse.Main;
-import edu.kpi.testcourse.dto.User;
 import edu.kpi.testcourse.dto.ShortLink;
+import edu.kpi.testcourse.dto.User;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/src/main/java/edu/kpi/testcourse/bigtable/BigTableManagerImpl.java
+++ b/src/main/java/edu/kpi/testcourse/bigtable/BigTableManagerImpl.java
@@ -2,7 +2,7 @@ package edu.kpi.testcourse.bigtable;
 
 import edu.kpi.testcourse.Main;
 import edu.kpi.testcourse.dto.User;
-import edu.kpi.testcourse.logic.ShortLinkMock;
+import edu.kpi.testcourse.dto.ShortLink;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -53,11 +53,11 @@ public class BigTableManagerImpl implements BigTableManager {
   }
 
   @Override
-  public Optional<ShortLinkMock> findShortLink(String shortLink) throws IOException {
+  public Optional<ShortLink> findShortLink(String shortLink) throws IOException {
     Path dataFolder = bigTable.getDir(DataFolder.Links);
     if (Files.exists(Path.of(dataFolder.toString(), shortLink))) {
       return Optional.of(Main.getGson().fromJson(bigTable.read(shortLink, DataFolder.Links),
-        ShortLinkMock.class));
+        ShortLink.class));
     } else {
       return Optional.empty();
     }
@@ -69,12 +69,12 @@ public class BigTableManagerImpl implements BigTableManager {
   }
 
   @Override
-  public ArrayList<ShortLinkMock> listAllUserLinks(String email) throws IOException {
+  public ArrayList<ShortLink> listAllUserLinks(String email) throws IOException {
     Path path = bigTable.getDir(DataFolder.Links);
     return Files.walk(path)
       .map((p) -> {
         try {
-          return Main.getGson().fromJson(Files.readString(p), ShortLinkMock.class);
+          return Main.getGson().fromJson(Files.readString(p), ShortLink.class);
         } catch (IOException exception) {
           exception.printStackTrace();
         }
@@ -86,7 +86,7 @@ public class BigTableManagerImpl implements BigTableManager {
   }
 
   @Override
-  public void storeLink(ShortLinkMock link) throws IOException {
+  public void storeLink(ShortLink link) throws IOException {
     String json = Main.getGson().toJson(link);
     bigTable.store(link.shortLink(), json, DataFolder.Links);
   }

--- a/src/main/java/edu/kpi/testcourse/dto/LinksOfUser.java
+++ b/src/main/java/edu/kpi/testcourse/dto/LinksOfUser.java
@@ -1,0 +1,30 @@
+package edu.kpi.testcourse.dto;
+
+import io.micronaut.core.annotation.Introspected;
+import java.util.ArrayList;
+
+/**
+ * DTO for urls of user in GET /urls.
+ */
+@Introspected
+public final class LinksOfUser {
+  private final ArrayList<ShortLink> urls;
+
+  /**
+   * Default constructor.
+   *
+   * @param urls ArrayList of ShortLink
+   */
+  public LinksOfUser(ArrayList<ShortLink> urls) {
+    this.urls = urls;
+  }
+
+  /**
+   * Getter for urls of user.
+   *
+   * @return urls
+   */
+  public ArrayList<ShortLink> urls() {
+    return this.urls;
+  }
+}

--- a/src/main/java/edu/kpi/testcourse/dto/ShortLink.java
+++ b/src/main/java/edu/kpi/testcourse/dto/ShortLink.java
@@ -10,19 +10,19 @@ import java.net.URL;
 public final class ShortLink {
   private String alias;
   private String email;
-  private URL url;
+  private String url;
 
   /**
    * Default constructor.
    *
-   * @param shortLink alias
-   * @param email user's
-   * @param destination llink
+   * @param alias alias for a "long" link
+   * @param email user's email
+   * @param url link to shorten
    */
-  public ShortLink(String shortLink, String email, URL destination) {
-    this.alias = shortLink;
+  public ShortLink(String alias, String email, String url) {
+    this.alias = alias;
     this.email = email;
-    this.url = destination;
+    this.url = url;
   }
 
   /**
@@ -48,7 +48,7 @@ public final class ShortLink {
    *
    * @return destination
    */
-  public URL url() {
+  public String url() {
     return url;
   }
 }

--- a/src/main/java/edu/kpi/testcourse/dto/ShortLink.java
+++ b/src/main/java/edu/kpi/testcourse/dto/ShortLink.java
@@ -1,11 +1,11 @@
-package edu.kpi.testcourse.logic;
+package edu.kpi.testcourse.dto;
 
 import java.net.URL;
 
 /**
  * Mock data for short link record in the data storage.
  */
-public class ShortLinkMock {
+public class ShortLink {
   private String shortLink;
   private String email;
   private URL destination;
@@ -17,7 +17,7 @@ public class ShortLinkMock {
    * @param email user's
    * @param destination llink
    */
-  public ShortLinkMock(String shortLink, String email, URL destination) {
+  public ShortLink(String shortLink, String email, URL destination) {
     this.shortLink = shortLink;
     this.email = email;
     this.destination = destination;

--- a/src/main/java/edu/kpi/testcourse/dto/ShortLink.java
+++ b/src/main/java/edu/kpi/testcourse/dto/ShortLink.java
@@ -4,7 +4,7 @@ import io.micronaut.core.annotation.Introspected;
 import java.net.URL;
 
 /**
- * Mock data for short link record in the data storage.
+ * Entity for short link record in the data storage.
  */
 @Introspected
 public final class ShortLink {

--- a/src/main/java/edu/kpi/testcourse/dto/ShortLink.java
+++ b/src/main/java/edu/kpi/testcourse/dto/ShortLink.java
@@ -1,14 +1,16 @@
 package edu.kpi.testcourse.dto;
 
+import io.micronaut.core.annotation.Introspected;
 import java.net.URL;
 
 /**
  * Mock data for short link record in the data storage.
  */
+@Introspected
 public final class ShortLink {
-  private String shortLink;
+  private String alias;
   private String email;
-  private URL destination;
+  private URL url;
 
   /**
    * Default constructor.
@@ -18,9 +20,9 @@ public final class ShortLink {
    * @param destination llink
    */
   public ShortLink(String shortLink, String email, URL destination) {
-    this.shortLink = shortLink;
+    this.alias = shortLink;
     this.email = email;
-    this.destination = destination;
+    this.url = destination;
   }
 
   /**
@@ -28,8 +30,8 @@ public final class ShortLink {
    *
    * @return shortLink
    */
-  public String shortLink() {
-    return shortLink;
+  public String alias() {
+    return alias;
   }
 
   /**
@@ -37,7 +39,7 @@ public final class ShortLink {
    *
    * @return email
    */
-  public String userEmail() {
+  public String email() {
     return email;
   }
 
@@ -46,7 +48,7 @@ public final class ShortLink {
    *
    * @return destination
    */
-  public URL destination() {
-    return destination;
+  public URL url() {
+    return url;
   }
 }

--- a/src/main/java/edu/kpi/testcourse/dto/ShortLink.java
+++ b/src/main/java/edu/kpi/testcourse/dto/ShortLink.java
@@ -5,7 +5,7 @@ import java.net.URL;
 /**
  * Mock data for short link record in the data storage.
  */
-public class ShortLink {
+public final class ShortLink {
   private String shortLink;
   private String email;
   private URL destination;

--- a/src/main/java/edu/kpi/testcourse/dto/User.java
+++ b/src/main/java/edu/kpi/testcourse/dto/User.java
@@ -1,10 +1,11 @@
 package edu.kpi.testcourse.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.core.annotation.Introspected;
 
 /**
  * Dto for User.
  */
+@Introspected
 public final class User {
 
   private String email;

--- a/src/main/java/edu/kpi/testcourse/exception/UrlsException.java
+++ b/src/main/java/edu/kpi/testcourse/exception/UrlsException.java
@@ -1,8 +1,0 @@
-package edu.kpi.testcourse.exception;
-
-/**
- * Exception for all situations with urls, specific data should be put in message.
- */
-public class UrlsException extends Exception {
-
-}

--- a/src/main/java/edu/kpi/testcourse/exception/UsersException.java
+++ b/src/main/java/edu/kpi/testcourse/exception/UsersException.java
@@ -1,8 +1,0 @@
-package edu.kpi.testcourse.exception;
-
-/**
- * Exception for all situations with users, specific data should be put in message.
- */
-public class UsersException extends Exception{
-
-}

--- a/src/main/java/edu/kpi/testcourse/exception/auth/UnauthorizedException.java
+++ b/src/main/java/edu/kpi/testcourse/exception/auth/UnauthorizedException.java
@@ -1,4 +1,4 @@
-package edu.kpi.testcourse.exception.user;
+package edu.kpi.testcourse.exception.auth;
 
 /**
  * Throw this exception if a JWT token is invalid or not provided.

--- a/src/main/java/edu/kpi/testcourse/exception/auth/UnauthorizedExceptionHandler.java
+++ b/src/main/java/edu/kpi/testcourse/exception/auth/UnauthorizedExceptionHandler.java
@@ -1,4 +1,4 @@
-package edu.kpi.testcourse.exception.user;
+package edu.kpi.testcourse.exception.auth;
 
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.HttpRequest;

--- a/src/main/java/edu/kpi/testcourse/exception/url/InvalidUrlException.java
+++ b/src/main/java/edu/kpi/testcourse/exception/url/InvalidUrlException.java
@@ -1,4 +1,4 @@
-package edu.kpi.testcourse.exception;
+package edu.kpi.testcourse.exception.url;
 
 /**
  * Throw this exception if user provides a wrong URL to shorten.

--- a/src/main/java/edu/kpi/testcourse/exception/url/InvalidUrlExceptionHandler.java
+++ b/src/main/java/edu/kpi/testcourse/exception/url/InvalidUrlExceptionHandler.java
@@ -1,4 +1,4 @@
-package edu.kpi.testcourse.exception;
+package edu.kpi.testcourse.exception.url;
 
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.HttpRequest;

--- a/src/main/java/edu/kpi/testcourse/exception/url/ShortLinkNotFoundException.java
+++ b/src/main/java/edu/kpi/testcourse/exception/url/ShortLinkNotFoundException.java
@@ -1,4 +1,4 @@
-package edu.kpi.testcourse.exception;
+package edu.kpi.testcourse.exception.url;
 
 /**
  * Throw this exception if an alias was not found in the data storage.

--- a/src/main/java/edu/kpi/testcourse/exception/url/ShortLinkNotFoundExceptionHandler.java
+++ b/src/main/java/edu/kpi/testcourse/exception/url/ShortLinkNotFoundExceptionHandler.java
@@ -1,4 +1,4 @@
-package edu.kpi.testcourse.exception;
+package edu.kpi.testcourse.exception.url;
 
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.HttpRequest;

--- a/src/main/java/edu/kpi/testcourse/exception/user/UnauthorizedException.java
+++ b/src/main/java/edu/kpi/testcourse/exception/user/UnauthorizedException.java
@@ -1,4 +1,4 @@
-package edu.kpi.testcourse.exception;
+package edu.kpi.testcourse.exception.user;
 
 /**
  * Throw this exception if a JWT token is invalid or not provided.

--- a/src/main/java/edu/kpi/testcourse/exception/user/UnauthorizedExceptionHandler.java
+++ b/src/main/java/edu/kpi/testcourse/exception/user/UnauthorizedExceptionHandler.java
@@ -1,4 +1,4 @@
-package edu.kpi.testcourse.exception;
+package edu.kpi.testcourse.exception.user;
 
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.http.HttpRequest;

--- a/src/main/java/edu/kpi/testcourse/logic/ShortLinkService.java
+++ b/src/main/java/edu/kpi/testcourse/logic/ShortLinkService.java
@@ -8,11 +8,11 @@ import java.util.Optional;
  * Business-logic class to provide read-write access to short links.
  */
 public interface ShortLinkService {
-  Optional<URL> getDestinationByShortLink(String shortLink);
+  Optional<String> getDestinationByShortLink(String shortLink);
 
   String generateAlias();
 
-  Optional<URL> safelyCreateUrl(String destination);
+  Optional<String> safelyCreateUrl(String destination);
 
   ShortLink saveLink(String userEmail, String destination);
 

--- a/src/main/java/edu/kpi/testcourse/logic/ShortLinkService.java
+++ b/src/main/java/edu/kpi/testcourse/logic/ShortLinkService.java
@@ -1,5 +1,6 @@
 package edu.kpi.testcourse.logic;
 
+import edu.kpi.testcourse.dto.ShortLink;
 import java.net.URL;
 import java.util.Optional;
 
@@ -13,7 +14,7 @@ public interface ShortLinkService {
 
   Optional<URL> safelyCreateUrl(String destination);
 
-  ShortLinkMock saveLink(String userEmail, String destination);
+  ShortLink saveLink(String userEmail, String destination);
 
-  ShortLinkMock saveLink(String userEmail, String destination, String alias);
+  ShortLink saveLink(String userEmail, String destination, String alias);
 }

--- a/src/main/java/edu/kpi/testcourse/logic/ShortLinkService.java
+++ b/src/main/java/edu/kpi/testcourse/logic/ShortLinkService.java
@@ -12,7 +12,7 @@ public interface ShortLinkService {
 
   String generateAlias();
 
-  Optional<String> safelyCreateUrl(String destination);
+  boolean isUrlValid(String destination);
 
   ShortLink saveLink(String userEmail, String destination);
 

--- a/src/main/java/edu/kpi/testcourse/logic/ShortLinkServiceImpl.java
+++ b/src/main/java/edu/kpi/testcourse/logic/ShortLinkServiceImpl.java
@@ -34,7 +34,7 @@ public class ShortLinkServiceImpl implements ShortLinkService {
   public Optional<URL> getDestinationByShortLink(String shortLink) {
     Optional<ShortLink> resp = linkRepo.findByShortLink(shortLink);
     return resp.isPresent()
-       ? Optional.of(resp.get().destination())
+       ? Optional.of(resp.get().url())
        : Optional.empty();
   }
 

--- a/src/main/java/edu/kpi/testcourse/logic/ShortLinkServiceImpl.java
+++ b/src/main/java/edu/kpi/testcourse/logic/ShortLinkServiceImpl.java
@@ -31,7 +31,7 @@ public class ShortLinkServiceImpl implements ShortLinkService {
    * @param shortLink short link
    * @return Optional - "long link" if it had been found in the storage
    */
-  public Optional<URL> getDestinationByShortLink(String shortLink) {
+  public Optional<String> getDestinationByShortLink(String shortLink) {
     Optional<ShortLink> resp = linkRepo.findByShortLink(shortLink);
     return resp.isPresent()
        ? Optional.of(resp.get().url())
@@ -110,11 +110,10 @@ public class ShortLinkServiceImpl implements ShortLinkService {
    * @param destination URL that should be validated
    * @return URL if it can be created
    */
-  public Optional<URL> safelyCreateUrl(String destination) {
-    try {
-      URL url = new URL(destination);
-      return Optional.of(url);
-    } catch (MalformedURLException e) {
+  public Optional<String> safelyCreateUrl(String destination) {
+    if (destination.startsWith("http://") || destination.startsWith("https://")) {
+      return Optional.of(destination);
+    } else {
       return Optional.empty();
     }
   }
@@ -138,7 +137,7 @@ public class ShortLinkServiceImpl implements ShortLinkService {
    */
   public ShortLink saveLink(String userEmail, String destination)
       throws InvalidUrlException {
-    Optional<URL> destinationLink = this.safelyCreateUrl(destination);
+    Optional<String> destinationLink = this.safelyCreateUrl(destination);
 
     if (destinationLink.isEmpty()) {
       throw new InvalidUrlException("Provided url is not valid http or https url");
@@ -164,7 +163,7 @@ public class ShortLinkServiceImpl implements ShortLinkService {
    */
   public ShortLink saveLink(String userEmail, String destination, String alias)
       throws InvalidUrlException {
-    Optional<URL> destinationLink = this.safelyCreateUrl(destination);
+    Optional<String> destinationLink = this.safelyCreateUrl(destination);
 
     if (destinationLink.isEmpty()) {
       throw new InvalidUrlException("Provided url is not valid http or https url");

--- a/src/main/java/edu/kpi/testcourse/logic/ShortLinkServiceImpl.java
+++ b/src/main/java/edu/kpi/testcourse/logic/ShortLinkServiceImpl.java
@@ -3,8 +3,6 @@ package edu.kpi.testcourse.logic;
 import edu.kpi.testcourse.dto.ShortLink;
 import edu.kpi.testcourse.exception.url.InvalidUrlException;
 import edu.kpi.testcourse.repository.LinkRepository;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Optional;
 import java.util.Random;

--- a/src/main/java/edu/kpi/testcourse/logic/ShortLinkServiceImpl.java
+++ b/src/main/java/edu/kpi/testcourse/logic/ShortLinkServiceImpl.java
@@ -1,7 +1,7 @@
 package edu.kpi.testcourse.logic;
 
 import edu.kpi.testcourse.dto.ShortLink;
-import edu.kpi.testcourse.exception.InvalidUrlException;
+import edu.kpi.testcourse.exception.url.InvalidUrlException;
 import edu.kpi.testcourse.repository.LinkRepository;
 import java.net.MalformedURLException;
 import java.net.URL;

--- a/src/main/java/edu/kpi/testcourse/logic/ShortLinkServiceImpl.java
+++ b/src/main/java/edu/kpi/testcourse/logic/ShortLinkServiceImpl.java
@@ -1,14 +1,13 @@
 package edu.kpi.testcourse.logic;
 
+import edu.kpi.testcourse.dto.ShortLink;
 import edu.kpi.testcourse.exception.InvalidUrlException;
 import edu.kpi.testcourse.repository.LinkRepository;
-import edu.kpi.testcourse.repository.LinkRepositoryImpl;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Optional;
 import java.util.Random;
-import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -33,7 +32,7 @@ public class ShortLinkServiceImpl implements ShortLinkService {
    * @return Optional - "long link" if it had been found in the storage
    */
   public Optional<URL> getDestinationByShortLink(String shortLink) {
-    Optional<ShortLinkMock> resp = linkRepo.findByShortLink(shortLink);
+    Optional<ShortLink> resp = linkRepo.findByShortLink(shortLink);
     return resp.isPresent()
        ? Optional.of(resp.get().destination())
        : Optional.empty();
@@ -56,7 +55,7 @@ public class ShortLinkServiceImpl implements ShortLinkService {
    * @param email email of user
    * @return list of user's links
    */
-  public ArrayList<ShortLinkMock> getLinksByUserEmail(String email) {
+  public ArrayList<ShortLink> getLinksByUserEmail(String email) {
     return linkRepo.getLinksOfUser(email);
   }
 
@@ -137,7 +136,7 @@ public class ShortLinkServiceImpl implements ShortLinkService {
    * @param destination - "long" link alias must be provided for
    * @return a link that has been created
    */
-  public ShortLinkMock saveLink(String userEmail, String destination)
+  public ShortLink saveLink(String userEmail, String destination)
       throws InvalidUrlException {
     Optional<URL> destinationLink = this.safelyCreateUrl(destination);
 
@@ -148,7 +147,7 @@ public class ShortLinkServiceImpl implements ShortLinkService {
       while (this.getDestinationByShortLink(alias).isPresent()) {
         alias = this.generateAlias();
       }
-      ShortLinkMock link = new ShortLinkMock(alias, userEmail, destinationLink.get());
+      ShortLink link = new ShortLink(alias, userEmail, destinationLink.get());
 
       linkRepo.saveLink(link);
 
@@ -163,7 +162,7 @@ public class ShortLinkServiceImpl implements ShortLinkService {
    * @param alias - custom user alias for a "long" link
    * @return a link that has been created
    */
-  public ShortLinkMock saveLink(String userEmail, String destination, String alias)
+  public ShortLink saveLink(String userEmail, String destination, String alias)
       throws InvalidUrlException {
     Optional<URL> destinationLink = this.safelyCreateUrl(destination);
 
@@ -174,7 +173,7 @@ public class ShortLinkServiceImpl implements ShortLinkService {
     } else if (!this.isAliasAlphanumeric(alias)) {
       throw new InvalidUrlException("Desired alias is not alphanumeric string");
     } else {
-      ShortLinkMock link = new ShortLinkMock(alias, userEmail, destinationLink.get());
+      ShortLink link = new ShortLink(alias, userEmail, destinationLink.get());
 
       linkRepo.saveLink(link);
 

--- a/src/main/java/edu/kpi/testcourse/repository/LinkRepository.java
+++ b/src/main/java/edu/kpi/testcourse/repository/LinkRepository.java
@@ -1,6 +1,6 @@
 package edu.kpi.testcourse.repository;
 
-import edu.kpi.testcourse.logic.ShortLinkMock;
+import edu.kpi.testcourse.dto.ShortLink;
 import java.util.ArrayList;
 import java.util.Optional;
 
@@ -9,11 +9,11 @@ import java.util.Optional;
  */
 public interface LinkRepository {
 
-  Optional<ShortLinkMock> findByShortLink(String shortLink);
+  Optional<ShortLink> findByShortLink(String shortLink);
 
   boolean deleteLink(String email, String shortLink);
 
-  ArrayList<ShortLinkMock> getLinksOfUser(String email);
+  ArrayList<ShortLink> getLinksOfUser(String email);
 
-  void saveLink(ShortLinkMock link);
+  void saveLink(ShortLink link);
 }

--- a/src/main/java/edu/kpi/testcourse/repository/LinkRepositoryImpl.java
+++ b/src/main/java/edu/kpi/testcourse/repository/LinkRepositoryImpl.java
@@ -1,8 +1,8 @@
 package edu.kpi.testcourse.repository;
 
 import edu.kpi.testcourse.bigtable.BigTableManager;
-import edu.kpi.testcourse.exception.bigtable.BigTableException;
 import edu.kpi.testcourse.dto.ShortLink;
+import edu.kpi.testcourse.exception.bigtable.BigTableException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Optional;

--- a/src/main/java/edu/kpi/testcourse/repository/LinkRepositoryImpl.java
+++ b/src/main/java/edu/kpi/testcourse/repository/LinkRepositoryImpl.java
@@ -48,7 +48,7 @@ public class LinkRepositoryImpl implements LinkRepository {
       if (link.isEmpty()) {
         return false;
       }
-      if (link.get().userEmail().equals(email)) {
+      if (link.get().email().equals(email)) {
         bigTableManager.deleteLink(shortLink);
         return true;
       } else {

--- a/src/main/java/edu/kpi/testcourse/repository/LinkRepositoryImpl.java
+++ b/src/main/java/edu/kpi/testcourse/repository/LinkRepositoryImpl.java
@@ -2,7 +2,7 @@ package edu.kpi.testcourse.repository;
 
 import edu.kpi.testcourse.bigtable.BigTableManager;
 import edu.kpi.testcourse.exception.bigtable.BigTableException;
-import edu.kpi.testcourse.logic.ShortLinkMock;
+import edu.kpi.testcourse.dto.ShortLink;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Optional;
@@ -26,7 +26,7 @@ public class LinkRepositoryImpl implements LinkRepository {
    * @return short link if it has been found
    */
   @Override
-  public Optional<ShortLinkMock> findByShortLink(String shortLink) {
+  public Optional<ShortLink> findByShortLink(String shortLink) {
     try {
       return bigTableManager.findShortLink(shortLink);
     } catch (IOException exception) {
@@ -44,7 +44,7 @@ public class LinkRepositoryImpl implements LinkRepository {
   @Override
   public boolean deleteLink(String email, String shortLink) {
     try {
-      Optional<ShortLinkMock> link = bigTableManager.findShortLink(shortLink);
+      Optional<ShortLink> link = bigTableManager.findShortLink(shortLink);
       if (link.isEmpty()) {
         return false;
       }
@@ -66,7 +66,7 @@ public class LinkRepositoryImpl implements LinkRepository {
    * @return ArrayList
    */
   @Override
-  public ArrayList<ShortLinkMock> getLinksOfUser(String email) {
+  public ArrayList<ShortLink> getLinksOfUser(String email) {
     try {
       return bigTableManager.listAllUserLinks(email);
     } catch (IOException exception) {
@@ -80,7 +80,7 @@ public class LinkRepositoryImpl implements LinkRepository {
    * @param link to save
    */
   @Override
-  public void saveLink(ShortLinkMock link) {
+  public void saveLink(ShortLink link) {
     try {
       bigTableManager.storeLink(link);
     } catch (IOException exception) {

--- a/src/main/java/edu/kpi/testcourse/rest/RedirectLinkController.java
+++ b/src/main/java/edu/kpi/testcourse/rest/RedirectLinkController.java
@@ -46,12 +46,12 @@ public class RedirectLinkController {
   @Get("/{link}")
   public HttpResponse<String> redirectByLink(@NotNull String link)
       throws URISyntaxException {
-    Optional<URL> redirectUrl = shortLinkService.getDestinationByShortLink(link);
+    Optional<String> redirectUrl = shortLinkService.getDestinationByShortLink(link);
 
     if (redirectUrl.isEmpty()) {
       throw new ShortLinkNotFoundException();
     } else {
-      URI location = new URI(redirectUrl.get().toExternalForm());
+      URI location = new URI(redirectUrl.get());
 
       return HttpResponse.redirect(location);
     }

--- a/src/main/java/edu/kpi/testcourse/rest/RedirectLinkController.java
+++ b/src/main/java/edu/kpi/testcourse/rest/RedirectLinkController.java
@@ -1,9 +1,8 @@
 package edu.kpi.testcourse.rest;
 
-import edu.kpi.testcourse.exception.ShortLinkNotFoundException;
+import edu.kpi.testcourse.exception.url.ShortLinkNotFoundException;
 import edu.kpi.testcourse.logic.ShortLinkServiceImpl;
 import io.micronaut.http.HttpResponse;
-import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;

--- a/src/main/java/edu/kpi/testcourse/rest/UrlController.java
+++ b/src/main/java/edu/kpi/testcourse/rest/UrlController.java
@@ -65,17 +65,16 @@ public class UrlController {
     if (urlToShorten.alias() != null) {
       shortLink = this.shortLinkService.saveLink(
         email,
-        urlToShorten.url().toString(),
+        urlToShorten.url(),
         urlToShorten.alias()
       );
     } else {
       shortLink = this.shortLinkService.saveLink(
         email,
-        urlToShorten.url().toString()
+        urlToShorten.url()
       );
     }
     String fullShortLink = ShortLinkServiceImpl.createFullLink(shortLink.alias());
-    System.out.println(fullShortLink);
 
     return Main.getGson().toJson(Collections.singletonMap("shortened_url", fullShortLink));
   }

--- a/src/main/java/edu/kpi/testcourse/rest/UrlController.java
+++ b/src/main/java/edu/kpi/testcourse/rest/UrlController.java
@@ -35,18 +35,6 @@ public class UrlController {
   @Inject
   AuthorizationMockServiceImpl authorizationMockService;
 
-  // /**
-  //  * Standard request body for POST /url/shorten.
-  //  */
-  // @Introspected
-  // public record UserUrl(String url, String alias) {}
-
-  // /**
-  //  * Standard response body for GET /urls.
-  //  */
-  // @Introspected
-  // public record UserUrls(ArrayList<ShortLink> urls) {}
-
   /**
    * Authorized user cen shorten an URL on this route.
    *

--- a/src/main/java/edu/kpi/testcourse/rest/UrlController.java
+++ b/src/main/java/edu/kpi/testcourse/rest/UrlController.java
@@ -2,9 +2,9 @@ package edu.kpi.testcourse.rest;
 
 import edu.kpi.testcourse.Main;
 import edu.kpi.testcourse.auth.AuthorizationMockServiceImpl;
+import edu.kpi.testcourse.dto.LinksOfUser;
 import edu.kpi.testcourse.dto.ShortLink;
 import edu.kpi.testcourse.logic.ShortLinkServiceImpl;
-import io.micronaut.core.annotation.Introspected;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.MutableHttpResponse;
@@ -18,7 +18,6 @@ import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.Produces;
 import io.micronaut.security.annotation.Secured;
 import io.micronaut.security.rules.SecurityRule;
-import java.util.ArrayList;
 import java.util.Collections;
 import javax.inject.Inject;
 import javax.validation.constraints.NotNull;
@@ -36,17 +35,17 @@ public class UrlController {
   @Inject
   AuthorizationMockServiceImpl authorizationMockService;
 
-  /**
-   * Standard request body for POST /url/shorten.
-   */
-  @Introspected
-  public record UserUrl(String url, String alias) {}
+  // /**
+  //  * Standard request body for POST /url/shorten.
+  //  */
+  // @Introspected
+  // public record UserUrl(String url, String alias) {}
 
-  /**
-   * Standard response body for GET /urls.
-   */
-  @Introspected
-  public record UserUrls(ArrayList<ShortLink> urls) {}
+  // /**
+  //  * Standard response body for GET /urls.
+  //  */
+  // @Introspected
+  // public record UserUrls(ArrayList<ShortLink> urls) {}
 
   /**
    * Authorized user cen shorten an URL on this route.
@@ -58,7 +57,7 @@ public class UrlController {
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.TEXT_PLAIN)
   @Post("/shorten")
-  public String shortenUrl(@Header("token") String token, @Body UserUrl urlToShorten) {
+  public String shortenUrl(@Header("token") String token, @Body ShortLink urlToShorten) {
     String email = this.authorizationMockService.authorizeUser(token);
 
     ShortLink shortLink;
@@ -66,16 +65,16 @@ public class UrlController {
     if (urlToShorten.alias() != null) {
       shortLink = this.shortLinkService.saveLink(
         email,
-        urlToShorten.url(),
+        urlToShorten.url().toString(),
         urlToShorten.alias()
       );
     } else {
       shortLink = this.shortLinkService.saveLink(
         email,
-        urlToShorten.url()
+        urlToShorten.url().toString()
       );
     }
-    String fullShortLink = ShortLinkServiceImpl.createFullLink(shortLink.shortLink());
+    String fullShortLink = ShortLinkServiceImpl.createFullLink(shortLink.alias());
     System.out.println(fullShortLink);
 
     return Main.getGson().toJson(Collections.singletonMap("shortened_url", fullShortLink));
@@ -101,9 +100,15 @@ public class UrlController {
     }
   }
 
+  /**
+   * Get urls that an authorized user had created.
+   *
+   * @param token jwt token the user is identified by
+   * @return list of urls
+   */
   @Get()
-  public MutableHttpResponse<UserUrls> getUserUrls(@Header String token) {
+  public MutableHttpResponse<LinksOfUser> getUserUrls(@Header String token) {
     String email = this.authorizationMockService.authorizeUser(token);
-    return HttpResponse.ok(new UserUrls(this.shortLinkService.getLinksByUserEmail(email)));
+    return HttpResponse.ok(new LinksOfUser(this.shortLinkService.getLinksByUserEmail(email)));
   }
 }

--- a/src/main/java/edu/kpi/testcourse/rest/UrlController.java
+++ b/src/main/java/edu/kpi/testcourse/rest/UrlController.java
@@ -2,7 +2,7 @@ package edu.kpi.testcourse.rest;
 
 import edu.kpi.testcourse.Main;
 import edu.kpi.testcourse.auth.AuthorizationMockServiceImpl;
-import edu.kpi.testcourse.logic.ShortLinkMock;
+import edu.kpi.testcourse.dto.ShortLink;
 import edu.kpi.testcourse.logic.ShortLinkServiceImpl;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.http.HttpResponse;
@@ -46,7 +46,7 @@ public class UrlController {
    * Standard response body for GET /urls.
    */
   @Introspected
-  public record UserUrls(ArrayList<ShortLinkMock> urls) {}
+  public record UserUrls(ArrayList<ShortLink> urls) {}
 
   /**
    * Authorized user cen shorten an URL on this route.
@@ -61,7 +61,7 @@ public class UrlController {
   public String shortenUrl(@Header("token") String token, @Body UserUrl urlToShorten) {
     String email = this.authorizationMockService.authorizeUser(token);
 
-    ShortLinkMock shortLink;
+    ShortLink shortLink;
 
     if (urlToShorten.alias() != null) {
       shortLink = this.shortLinkService.saveLink(

--- a/src/main/java/edu/kpi/testcourse/rest/UrlController.java
+++ b/src/main/java/edu/kpi/testcourse/rest/UrlController.java
@@ -36,7 +36,7 @@ public class UrlController {
   AuthorizationMockServiceImpl authorizationMockService;
 
   /**
-   * Authorized user cen shorten an URL on this route.
+   * Authorized user can shorten a URL on this route.
    *
    * @param token - bearer auth JWT token to check if user is authorized.
    * @param urlToShorten - URL with unnecessary alias that must be shortened.

--- a/src/test/java/edu/kpi/testcourse/bigtable/BigTableManagerTest.java
+++ b/src/test/java/edu/kpi/testcourse/bigtable/BigTableManagerTest.java
@@ -34,8 +34,7 @@ public class BigTableManagerTest {
   @BeforeAll
   public static void init() throws MalformedURLException {
     testUser = new User("testMail", "testPass");
-    shortLink = new ShortLink("testShort", "testMail",
-      new URL("https://google.com"));
+    shortLink = new ShortLink("testShort", "testMail","https://google.com");
     testUserJson = Main.getGson().toJson(testUser, User.class);
     shortLinkJson = Main.getGson().toJson(shortLink, ShortLink.class);
   }

--- a/src/test/java/edu/kpi/testcourse/bigtable/BigTableManagerTest.java
+++ b/src/test/java/edu/kpi/testcourse/bigtable/BigTableManagerTest.java
@@ -3,7 +3,7 @@ package edu.kpi.testcourse.bigtable;
 
 import edu.kpi.testcourse.Main;
 import edu.kpi.testcourse.dto.User;
-import edu.kpi.testcourse.logic.ShortLinkMock;
+import edu.kpi.testcourse.dto.ShortLink;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -27,17 +27,17 @@ public class BigTableManagerTest {
   private BigTableManagerImpl bigTableManager;
 
   private static User testUser;
-  private static ShortLinkMock shortLink;
+  private static ShortLink shortLink;
   private static String testUserJson;
   private static String shortLinkJson;
 
   @BeforeAll
   public static void init() throws MalformedURLException {
     testUser = new User("testMail", "testPass");
-    shortLink = new ShortLinkMock("testShort", "testMail",
+    shortLink = new ShortLink("testShort", "testMail",
       new URL("https://google.com"));
     testUserJson = Main.getGson().toJson(testUser, User.class);
-    shortLinkJson = Main.getGson().toJson(shortLink, ShortLinkMock.class);
+    shortLinkJson = Main.getGson().toJson(shortLink, ShortLink.class);
   }
 
   @BeforeEach
@@ -102,9 +102,9 @@ public class BigTableManagerTest {
   public void managerFindsAllLinksOfUser() {
     assertDoesNotThrow(() -> bigTableManager.storeLink(shortLink));
     assertDoesNotThrow(() -> {
-      ArrayList<ShortLinkMock> list = bigTableManager.listAllUserLinks(shortLink.userEmail());
+      ArrayList<ShortLink> list = bigTableManager.listAllUserLinks(shortLink.userEmail());
       assertEquals(1, list.size());
-      ShortLinkMock resp = list.get(0);
+      ShortLink resp = list.get(0);
       assertEquals(shortLink.userEmail(), resp.userEmail());
       assertEquals(shortLink.shortLink(), resp.shortLink());
       assertEquals(shortLink.destination(), resp.destination());
@@ -121,7 +121,7 @@ public class BigTableManagerTest {
   public void managerFindsShortLinkByAlias() {
     assertDoesNotThrow(() -> bigTableManager.storeLink(shortLink));
     assertDoesNotThrow(() -> {
-      ShortLinkMock resp = bigTableManager.findShortLink(shortLink.shortLink()).get();
+      ShortLink resp = bigTableManager.findShortLink(shortLink.shortLink()).get();
       assertEquals(shortLink.userEmail(), resp.userEmail());
       assertEquals(shortLink.shortLink(), resp.shortLink());
       assertEquals(shortLink.destination(), resp.destination());

--- a/src/test/java/edu/kpi/testcourse/bigtable/BigTableManagerTest.java
+++ b/src/test/java/edu/kpi/testcourse/bigtable/BigTableManagerTest.java
@@ -50,9 +50,9 @@ public class BigTableManagerTest {
       }
     }
     if (Files.exists(Paths.get(bigTable.getDir(DataFolder.Links).toString(),
-      shortLink.shortLink()))) {
+      shortLink.alias()))) {
       try {
-        bigTable.delete(shortLink.shortLink(), DataFolder.Links);
+        bigTable.delete(shortLink.alias(), DataFolder.Links);
       } catch (IOException exception) {
         exception.printStackTrace();
       }
@@ -94,7 +94,7 @@ public class BigTableManagerTest {
   public void managerStoresLink() {
     assertDoesNotThrow(() -> bigTableManager.storeLink(shortLink));
     assertDoesNotThrow(() -> {
-      assertEquals(shortLinkJson, bigTable.read(shortLink.shortLink(), DataFolder.Links));
+      assertEquals(shortLinkJson, bigTable.read(shortLink.alias(), DataFolder.Links));
     });
   }
 
@@ -102,36 +102,36 @@ public class BigTableManagerTest {
   public void managerFindsAllLinksOfUser() {
     assertDoesNotThrow(() -> bigTableManager.storeLink(shortLink));
     assertDoesNotThrow(() -> {
-      ArrayList<ShortLink> list = bigTableManager.listAllUserLinks(shortLink.userEmail());
+      ArrayList<ShortLink> list = bigTableManager.listAllUserLinks(shortLink.email());
       assertEquals(1, list.size());
       ShortLink resp = list.get(0);
-      assertEquals(shortLink.userEmail(), resp.userEmail());
-      assertEquals(shortLink.shortLink(), resp.shortLink());
-      assertEquals(shortLink.destination(), resp.destination());
+      assertEquals(shortLink.email(), resp.email());
+      assertEquals(shortLink.alias(), resp.alias());
+      assertEquals(shortLink.url(), resp.url());
     });
   }
 
   @Test
   public void managerDeletesLink() {
     assertDoesNotThrow(() -> bigTableManager.storeLink(shortLink));
-    assertDoesNotThrow(() -> bigTableManager.deleteLink(shortLink.shortLink()));
+    assertDoesNotThrow(() -> bigTableManager.deleteLink(shortLink.alias()));
   }
 
   @Test
   public void managerFindsShortLinkByAlias() {
     assertDoesNotThrow(() -> bigTableManager.storeLink(shortLink));
     assertDoesNotThrow(() -> {
-      ShortLink resp = bigTableManager.findShortLink(shortLink.shortLink()).get();
-      assertEquals(shortLink.userEmail(), resp.userEmail());
-      assertEquals(shortLink.shortLink(), resp.shortLink());
-      assertEquals(shortLink.destination(), resp.destination());
+      ShortLink resp = bigTableManager.findShortLink(shortLink.alias()).get();
+      assertEquals(shortLink.email(), resp.email());
+      assertEquals(shortLink.alias(), resp.alias());
+      assertEquals(shortLink.url(), resp.url());
     });
   }
 
   @Test
   public void returnsEmptyWhenLinkDoesNotExist() {
     assertDoesNotThrow(() -> {
-      assertEquals(Optional.empty(), bigTableManager.findShortLink(shortLink.shortLink()));
+      assertEquals(Optional.empty(), bigTableManager.findShortLink(shortLink.alias()));
     });
   }
 }

--- a/src/test/java/edu/kpi/testcourse/logic/ShortLinkServiceTest.java
+++ b/src/test/java/edu/kpi/testcourse/logic/ShortLinkServiceTest.java
@@ -138,12 +138,12 @@ public class ShortLinkServiceTest {
     var test1 = new ShortLink(
       "character",
       "user1@mail.com",
-      new URL("https://en.wikipedia.org/wiki/Kakashi_Hatake")
+      "https://en.wikipedia.org/wiki/Kakashi_Hatake"
     );
     var test2 =new ShortLink(
       linkWithRandomAlias.alias(),
       "user1@mail.com",
-      new URL("https://github.com/metarhia/metasql")
+      "https://github.com/metarhia/metasql"
     );
     ArrayList<ShortLink> resp = provider.getLinksByUserEmail("user1@mail.com");
     assertThat(resp.stream().anyMatch((s) -> s.email().equals(test1.email()))).isTrue();

--- a/src/test/java/edu/kpi/testcourse/logic/ShortLinkServiceTest.java
+++ b/src/test/java/edu/kpi/testcourse/logic/ShortLinkServiceTest.java
@@ -2,6 +2,7 @@ package edu.kpi.testcourse.logic;
 
 import edu.kpi.testcourse.bigtable.BigTable;
 import edu.kpi.testcourse.bigtable.DataFolder;
+import edu.kpi.testcourse.dto.ShortLink;
 import edu.kpi.testcourse.exception.InvalidUrlException;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import java.io.IOException;
@@ -10,9 +11,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import javax.inject.Inject;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -111,7 +110,7 @@ public class ShortLinkServiceTest {
 
   @Test
   public void shouldRetrieveSavedLinks() {
-    ShortLinkMock shortLink = provider.saveLink(
+    ShortLink shortLink = provider.saveLink(
       "user3@mail.com",
       "https://en.wikipedia.org/wiki/Al-Ahsa_Oasis"
     );
@@ -127,7 +126,7 @@ public class ShortLinkServiceTest {
       "https://en.wikipedia.org/wiki/Kakashi_Hatake",
       "character"
     );
-    ShortLinkMock linkWithRandomAlias = provider.saveLink(
+    ShortLink linkWithRandomAlias = provider.saveLink(
       "user1@mail.com",
       "https://github.com/metarhia/metasql"
     );
@@ -136,17 +135,17 @@ public class ShortLinkServiceTest {
       "https://commons.wikimedia.org/wiki/File:Chestnut-tailed_starling_-_%E0%A6%95%E0%A6%BE%E0%A6%A0_%E0%A6%B6%E0%A6%BE%E0%A6%B2%E0%A6%BF%E0%A6%95.jpg",
       "birds"
     );
-    var test1 = new ShortLinkMock(
+    var test1 = new ShortLink(
       "character",
       "user1@mail.com",
       new URL("https://en.wikipedia.org/wiki/Kakashi_Hatake")
     );
-    var test2 =new ShortLinkMock(
+    var test2 =new ShortLink(
       linkWithRandomAlias.shortLink(),
       "user1@mail.com",
       new URL("https://github.com/metarhia/metasql")
     );
-    ArrayList<ShortLinkMock> resp = provider.getLinksByUserEmail("user1@mail.com");
+    ArrayList<ShortLink> resp = provider.getLinksByUserEmail("user1@mail.com");
     assertThat(resp.stream().anyMatch((s) -> s.userEmail().equals(test1.userEmail()))).isTrue();
     assertThat(resp.stream().anyMatch((s) -> s.userEmail().equals(test2.userEmail()))).isTrue();
   }
@@ -158,7 +157,7 @@ public class ShortLinkServiceTest {
       "https://stackoverflow.com/questions/31079081/programmatically-navigate-using-react-router",
       "sof"
     );
-    ShortLinkMock shortLinkRandomAlias = provider.saveLink(
+    ShortLink shortLinkRandomAlias = provider.saveLink(
       "user1@mail.com",
       "https://en.wikipedia.org/wiki/Chestnut-tailed_starling"
     );

--- a/src/test/java/edu/kpi/testcourse/logic/ShortLinkServiceTest.java
+++ b/src/test/java/edu/kpi/testcourse/logic/ShortLinkServiceTest.java
@@ -3,7 +3,7 @@ package edu.kpi.testcourse.logic;
 import edu.kpi.testcourse.bigtable.BigTable;
 import edu.kpi.testcourse.bigtable.DataFolder;
 import edu.kpi.testcourse.dto.ShortLink;
-import edu.kpi.testcourse.exception.InvalidUrlException;
+import edu.kpi.testcourse.exception.url.InvalidUrlException;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import java.io.IOException;
 import java.net.MalformedURLException;

--- a/src/test/java/edu/kpi/testcourse/logic/ShortLinkServiceTest.java
+++ b/src/test/java/edu/kpi/testcourse/logic/ShortLinkServiceTest.java
@@ -115,8 +115,8 @@ public class ShortLinkServiceTest {
       "https://en.wikipedia.org/wiki/Al-Ahsa_Oasis"
     );
 
-    assertThat(provider.getDestinationByShortLink(shortLink.shortLink()).get())
-      .isEqualTo(shortLink.destination());
+    assertThat(provider.getDestinationByShortLink(shortLink.alias()).get())
+      .isEqualTo(shortLink.url());
   }
 
   @Test
@@ -141,13 +141,13 @@ public class ShortLinkServiceTest {
       new URL("https://en.wikipedia.org/wiki/Kakashi_Hatake")
     );
     var test2 =new ShortLink(
-      linkWithRandomAlias.shortLink(),
+      linkWithRandomAlias.alias(),
       "user1@mail.com",
       new URL("https://github.com/metarhia/metasql")
     );
     ArrayList<ShortLink> resp = provider.getLinksByUserEmail("user1@mail.com");
-    assertThat(resp.stream().anyMatch((s) -> s.userEmail().equals(test1.userEmail()))).isTrue();
-    assertThat(resp.stream().anyMatch((s) -> s.userEmail().equals(test2.userEmail()))).isTrue();
+    assertThat(resp.stream().anyMatch((s) -> s.email().equals(test1.email()))).isTrue();
+    assertThat(resp.stream().anyMatch((s) -> s.email().equals(test2.email()))).isTrue();
   }
 
   @Test
@@ -169,7 +169,7 @@ public class ShortLinkServiceTest {
 
     // delete all urls of user1@mail.com
     provider.deleteLinkIfBelongsToUser("user1@mail.com", "sof");
-    provider.deleteLinkIfBelongsToUser("user1@mail.com", shortLinkRandomAlias.shortLink());
+    provider.deleteLinkIfBelongsToUser("user1@mail.com", shortLinkRandomAlias.alias());
 
     assertThat(provider.getLinksByUserEmail("user1@mail.com")).isEmpty();
   }

--- a/src/test/java/edu/kpi/testcourse/logic/ShortLinkServiceTest.java
+++ b/src/test/java/edu/kpi/testcourse/logic/ShortLinkServiceTest.java
@@ -6,8 +6,6 @@ import edu.kpi.testcourse.dto.ShortLink;
 import edu.kpi.testcourse.exception.url.InvalidUrlException;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -25,7 +23,6 @@ public class ShortLinkServiceTest {
   private ShortLinkServiceImpl provider;
   @Inject
   private BigTable bigTable;
-
 
   private static final String userEmail = "test_user@mail.com";
 
@@ -92,7 +89,7 @@ public class ShortLinkServiceTest {
     assertThatThrownBy(() -> provider.saveLink(userEmail, url, existentAlias))
       .isInstanceOf(InvalidUrlException.class);
 
-    assertThat(provider.getDestinationByShortLink(existentAlias).get().toString())
+    assertThat(provider.getDestinationByShortLink(existentAlias).get())
       .isEqualTo("https://darcs.realworldhaskell.org/static/00book.pdf");
   }
 
@@ -120,7 +117,7 @@ public class ShortLinkServiceTest {
   }
 
   @Test
-  public void shouldRetrieveCorrectUrlsByUsersEmail() throws MalformedURLException {
+  public void shouldRetrieveCorrectUrlsByUsersEmail() {
     provider.saveLink(
       "user1@mail.com",
       "https://en.wikipedia.org/wiki/Kakashi_Hatake",

--- a/src/test/java/edu/kpi/testcourse/rest/RedirectLinkTest.java
+++ b/src/test/java/edu/kpi/testcourse/rest/RedirectLinkTest.java
@@ -1,5 +1,7 @@
 package edu.kpi.testcourse.rest;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 import com.google.gson.Gson;
 import edu.kpi.testcourse.dto.ShortLink;
 import io.micronaut.context.ApplicationContext;
@@ -7,6 +9,12 @@ import io.micronaut.http.HttpRequest;
 import io.micronaut.http.client.HttpClient;
 import io.micronaut.runtime.server.EmbeddedServer;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Comparator;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -77,6 +85,18 @@ public class RedirectLinkTest {
     if (client != null) {
       client.stop();
     }
+
+    // clear all links in 'links' directory
+    // temporary solution before we configure our data storage properly
+    assertDoesNotThrow(() -> {
+      Path linksPath = Paths.get("data/links/");
+
+      try (Stream<Path> walk = Files.walk(linksPath)) {
+        walk.sorted(Comparator.reverseOrder())
+          .map(Path::toFile)
+          .forEach(File::delete);
+      }
+    });
   }
 
   @Test

--- a/src/test/java/edu/kpi/testcourse/rest/RedirectLinkTest.java
+++ b/src/test/java/edu/kpi/testcourse/rest/RedirectLinkTest.java
@@ -10,7 +10,6 @@ import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.*;
 
 @MicronautTest
 public class RedirectLinkTest {
@@ -38,40 +37,36 @@ public class RedirectLinkTest {
       .getApplicationContext()
       .createBean(HttpClient.class, server.getURL());
 
-    assertDoesNotThrow(() -> {
-      String url1 = "https://devblogs.microsoft.com/typescript/announcing-the-new-typescript-handbook/";
-      String url2 = "https://darcs.realworldhaskell.org/static/00book.pdf";
+    String url1 = "https://devblogs.microsoft.com/typescript/announcing-the-new-typescript-handbook/";
+    String url2 = "https://darcs.realworldhaskell.org/static/00book.pdf";
 
-      System.out.println(url1);
-
-      String noAliasBody = client.toBlocking().retrieve(
-        HttpRequest.POST(
-          "/urls/shorten",
-          g.toJson(
-            new ShortLink(
-              null,
-              null,
-              url1
-            )
+    String noAliasBody = client.toBlocking().retrieve(
+      HttpRequest.POST(
+        "/urls/shorten",
+        g.toJson(
+          new ShortLink(
+            null,
+            null,
+            url1
           )
-        ).header("token", TEST_VALID_TOKEN)
-      );
-      String withAliasBody = client.toBlocking().retrieve(
-        HttpRequest.POST(
-          "/urls/shorten",
-          g.toJson(
-            new ShortLink(
-              "haskell",
-              "user1@mail.com",
-              url2
-            )
+        )
+      ).header("token", TEST_VALID_TOKEN)
+    );
+    String withAliasBody = client.toBlocking().retrieve(
+      HttpRequest.POST(
+        "/urls/shorten",
+        g.toJson(
+          new ShortLink(
+            "haskell",
+            "user1@mail.com",
+            url2
           )
-        ).header("token", TEST_VALID_TOKEN)
-      );
+        )
+      ).header("token", TEST_VALID_TOKEN)
+    );
 
-      randomAlias = getShortenedUrlFromResponseBody(noAliasBody);
-      customAlias = getShortenedUrlFromResponseBody(withAliasBody);
-    });
+    randomAlias = getShortenedUrlFromResponseBody(noAliasBody);
+    customAlias = getShortenedUrlFromResponseBody(withAliasBody);
   }
 
   @AfterAll
@@ -86,27 +81,25 @@ public class RedirectLinkTest {
 
   @Test
   public void registeredShouldRedirect() {
-    assertDoesNotThrow(() -> {
-      String withAliasBody2 = client.toBlocking().retrieve(
-        HttpRequest.POST(
-          "/urls/shorten",
-          g.toJson(
-            new ShortLink(
-              "haskell2",
-              "user1@mail.com",
-              "https://darcs.realworldhaskell.org/static/00book.pdf"
-            )
+    String withAliasBody2 = client.toBlocking().retrieve(
+      HttpRequest.POST(
+        "/urls/shorten",
+        g.toJson(
+          new ShortLink(
+            "haskell2",
+            "user1@mail.com",
+            "https://darcs.realworldhaskell.org/static/00book.pdf"
           )
-        ).header("token", TEST_VALID_TOKEN)
-      );
-      String customAlias2 = getShortenedUrlFromResponseBody(withAliasBody2);
+        )
+      ).header("token", TEST_VALID_TOKEN)
+    );
+    String customAlias2 = getShortenedUrlFromResponseBody(withAliasBody2);
 
-    /*String responseBody = client.toBlocking()
-      .retrieve(
-        HttpRequest.GET("/r/haskell2")
-          .header("token", TEST_VALID_TOKEN)
-      );*/
-    });
+    /* String responseBody = client.toBlocking()
+    .retrieve(
+      HttpRequest.GET("/r/haskell2")
+        .header("token", TEST_VALID_TOKEN)
+    );*/
   }
 
   @Test

--- a/src/test/java/edu/kpi/testcourse/rest/RedirectLinkTest.java
+++ b/src/test/java/edu/kpi/testcourse/rest/RedirectLinkTest.java
@@ -86,22 +86,27 @@ public class RedirectLinkTest {
 
   @Test
   public void registeredShouldRedirect() {
-    /* assertDoesNotThrow(() -> {
+    assertDoesNotThrow(() -> {
       String withAliasBody2 = client.toBlocking().retrieve(
-        HttpRequest.POST("/urls/shorten", new ShortLink(
-          "haskell2",
-          "user1@mail.com",
-          new URL("https://darcs.realworldhaskell.org/static/00book.pdf")
-        )).header("token", TEST_VALID_TOKEN)
+        HttpRequest.POST(
+          "/urls/shorten",
+          g.toJson(
+            new ShortLink(
+              "haskell2",
+              "user1@mail.com",
+              "https://darcs.realworldhaskell.org/static/00book.pdf"
+            )
+          )
+        ).header("token", TEST_VALID_TOKEN)
       );
       String customAlias2 = getShortenedUrlFromResponseBody(withAliasBody2);
 
-    String responseBody = client.toBlocking()
+    /*String responseBody = client.toBlocking()
       .retrieve(
         HttpRequest.GET("/r/haskell2")
           .header("token", TEST_VALID_TOKEN)
       );*/
-    // });
+    });
   }
 
   @Test

--- a/src/test/java/edu/kpi/testcourse/rest/RedirectLinkTest.java
+++ b/src/test/java/edu/kpi/testcourse/rest/RedirectLinkTest.java
@@ -3,12 +3,10 @@ package edu.kpi.testcourse.rest;
 import com.google.gson.Gson;
 import edu.kpi.testcourse.dto.ShortLink;
 import io.micronaut.context.ApplicationContext;
-import io.micronaut.core.annotation.Introspected;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.client.HttpClient;
 import io.micronaut.runtime.server.EmbeddedServer;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
-import java.net.URL;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -47,11 +45,16 @@ public class RedirectLinkTest {
       System.out.println(url1);
 
       String noAliasBody = client.toBlocking().retrieve(
-        HttpRequest.POST("/urls/shorten", g.toJson(new ShortLink(
-          null,
-          null,
-          url1
-        ))).header("token", TEST_VALID_TOKEN)
+        HttpRequest.POST(
+          "/urls/shorten",
+          g.toJson(
+            new ShortLink(
+              null,
+              null,
+              url1
+            )
+          )
+        ).header("token", TEST_VALID_TOKEN)
       );
       String withAliasBody = client.toBlocking().retrieve(
         HttpRequest.POST(

--- a/src/test/java/edu/kpi/testcourse/rest/RedirectLinkTest.java
+++ b/src/test/java/edu/kpi/testcourse/rest/RedirectLinkTest.java
@@ -7,12 +7,14 @@ import io.micronaut.core.annotation.Introspected;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.client.HttpClient;
 import io.micronaut.runtime.server.EmbeddedServer;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import java.net.URL;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
+@MicronautTest
 public class RedirectLinkTest {
   private static final String TEST_VALID_TOKEN = "eyJhbGciOiJIUzI1NiJ9.eyJJc3N1ZXIiOiJ1c2VyMUBtYWlsLmNvbSIsImV4cCI6MTY0NjczMDczOCwia"
     + "WF0IjoxNjE1MTk0NzM4fQ.SYb7CJl3Gx0AyeHcRGR6jWr6Gbxg0m8b7V2ZhynrYuY";
@@ -26,46 +28,46 @@ public class RedirectLinkTest {
   private static HttpClient client;
   private static final Gson g = new Gson();
 
-  /* @Introspected
-  private static class ShortenedUrlResponse {
-    public String shortened_url;
-  }*/
-
   private static String getShortenedUrlFromResponseBody(String body) {
     ShortLink parsed = g.fromJson(body, ShortLink.class);
     return parsed.alias();
   }
 
-  @Test
-  public void setupServer() {
+  @BeforeAll
+  public static void setupServer() {
     server = ApplicationContext.run(EmbeddedServer.class);
     client = server
       .getApplicationContext()
       .createBean(HttpClient.class, server.getURL());
 
     assertDoesNotThrow(() -> {
-      URL url1 = new URL("https://devblogs.microsoft.com/typescript/announcing-the-new-typescript-handbook/");
-      URL url2 = new URL("https://darcs.realworldhaskell.org/static/00book.pdf");
+      String url1 = "https://devblogs.microsoft.com/typescript/announcing-the-new-typescript-handbook/";
+      String url2 = "https://darcs.realworldhaskell.org/static/00book.pdf";
 
       System.out.println(url1);
 
       String noAliasBody = client.toBlocking().retrieve(
-        HttpRequest.POST("/urls/shorten", new ShortLink(
+        HttpRequest.POST("/urls/shorten", g.toJson(new ShortLink(
           null,
           null,
           url1
-        )).header("token", TEST_VALID_TOKEN)
+        ))).header("token", TEST_VALID_TOKEN)
       );
-      /* String withAliasBody = client.toBlocking().retrieve(
-        HttpRequest.POST("/urls/shorten", new ShortLink(
-          "haskell",
-          "user1@mail.com",
-          url2
-        )).header("token", TEST_VALID_TOKEN)
+      String withAliasBody = client.toBlocking().retrieve(
+        HttpRequest.POST(
+          "/urls/shorten",
+          g.toJson(
+            new ShortLink(
+              "haskell",
+              "user1@mail.com",
+              url2
+            )
+          )
+        ).header("token", TEST_VALID_TOKEN)
       );
 
       randomAlias = getShortenedUrlFromResponseBody(noAliasBody);
-      customAlias = getShortenedUrlFromResponseBody(withAliasBody);*/
+      customAlias = getShortenedUrlFromResponseBody(withAliasBody);
     });
   }
 

--- a/src/test/java/edu/kpi/testcourse/rest/ShortenLinkTest.java
+++ b/src/test/java/edu/kpi/testcourse/rest/ShortenLinkTest.java
@@ -1,17 +1,19 @@
 package edu.kpi.testcourse.rest;
 
 import com.google.gson.Gson;
-import edu.kpi.testcourse.rest.UrlController.UserUrl;
+import edu.kpi.testcourse.dto.ShortLink;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.client.HttpClient;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import io.micronaut.runtime.server.EmbeddedServer;
+import java.net.URL;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -21,6 +23,7 @@ public class ShortenLinkTest {
     + "WF0IjoxNjE1MTk0NzM4fQ.SYb7CJl3Gx0AyeHcRGR6jWr6Gbxg0m8b7V2ZhynrYuY";
   private static final String TEST_VALID_TOKEN2 = "eyJhbGciOiJIUzI1NiJ9.eyJJc3N1ZXIiOiJ1c2VyMkBtYWlsLmNvbSIsImV4cCI6MTY0NjczMDczOCwia"
     + "WF0IjoxNjE1MTk0NzM4fQ.1VyiEw77yt998_6zNp-fxSMwpMyY93beRMMLno_uKSg";
+  private static final String userEmail = "user1@mail.com";
 
   private static EmbeddedServer server;
   private static HttpClient client;
@@ -82,16 +85,19 @@ public class ShortenLinkTest {
 
   @Test
   public void shouldSaveValidUrl() {
-    String body = client.toBlocking().retrieve(
-      HttpRequest.POST("/urls/shorten", new UserUrl(
-        "https://devblogs.microsoft.com/typescript/announcing-the-new-typescript-handbook/",
-        null
-      )).header("token", TEST_VALID_TOKEN)
-    );
+    assertDoesNotThrow(() -> {
+      String body = client.toBlocking().retrieve(
+        HttpRequest.POST("/urls/shorten", new ShortLink(
+          null,
+          null,
+          new URL("https://devblogs.microsoft.com/typescript/announcing-the-new-typescript-handbook/")
+        )).header("token", TEST_VALID_TOKEN)
+      );
 
-    Object parsedBody = g.fromJson(body, Object.class);
+      Object parsedBody = g.fromJson(body, Object.class);
 
-    assertThat(parsedBody).hasFieldOrProperty("shortened_url");
+      assertThat(parsedBody).hasFieldOrProperty("shortened_url");
+    });
   }
 
   @Test
@@ -99,9 +105,10 @@ public class ShortenLinkTest {
     HttpClientResponseException e = assertThrows(
       HttpClientResponseException.class,
       () -> client.toBlocking().retrieve(
-      HttpRequest.POST("/urls/shorten", new UserUrl(
-        "ht/devblogs.microsoft.com/typescript/announcing-the-new-typescript-handbook/",
-        null
+      HttpRequest.POST("/urls/shorten", new ShortLink(
+        null,
+        null,
+        new URL("ht/devblogs.microsoft.com/typescript/announcing-the-new-typescript-handbook/")
       )).header("token", TEST_VALID_TOKEN)
       )
     );
@@ -113,13 +120,16 @@ public class ShortenLinkTest {
   public void shouldSaveWithAlias() {
     String alias = "alias";
 
-    String body = client.toBlocking().retrieve(
-      HttpRequest.POST("/urls/shorten", new UserUrl(
-        "https://devblogs.microsoft.com/typescript/announcing-the-new-typescript-handbook/",
-        alias
-      )).header("token", TEST_VALID_TOKEN)
-    );
+    assertDoesNotThrow(() -> {
+      String body = client.toBlocking().retrieve(
+        HttpRequest.POST("/urls/shorten", new ShortLink(
+          alias,
+          null,
+          new URL("https://devblogs.microsoft.com/typescript/announcing-the-new-typescript-handbook/")
+        )).header("token", TEST_VALID_TOKEN)
+      );
 
-    assertThat(body.contains("\"shortened_url\":\"http://localhost:8080/r/alias\"")).isEqualTo(true);
+      assertThat(body.contains("\"shortened_url\":\"http://localhost:8080/r/alias\"")).isEqualTo(true);
+    });
   }
 }

--- a/src/test/java/edu/kpi/testcourse/rest/ShortenLinkTest.java
+++ b/src/test/java/edu/kpi/testcourse/rest/ShortenLinkTest.java
@@ -91,7 +91,7 @@ public class ShortenLinkTest {
       )
     );
 
-    assertEquals(400, e.getStatus().getCode());
+    assertEquals(401, e.getStatus().getCode());
   }
 
   @Test

--- a/src/test/java/edu/kpi/testcourse/rest/ShortenLinkTest.java
+++ b/src/test/java/edu/kpi/testcourse/rest/ShortenLinkTest.java
@@ -118,18 +118,16 @@ public class ShortenLinkTest {
       )
     );
 
-    assertDoesNotThrow(() -> {
-      String body = client.toBlocking().retrieve(
-        HttpRequest.POST(
-          "/urls/shorten",
-          requestBody
-        ).header("token", TEST_VALID_TOKEN)
-      );
+    String body = client.toBlocking().retrieve(
+      HttpRequest.POST(
+        "/urls/shorten",
+        requestBody
+      ).header("token", TEST_VALID_TOKEN)
+    );
 
-      Object parsedBody = g.fromJson(body, Object.class);
+    Object parsedBody = g.fromJson(body, Object.class);
 
-      assertThat(parsedBody).hasFieldOrProperty("shortened_url");
-    });
+    assertThat(parsedBody).hasFieldOrProperty("shortened_url");
   }
 
   @Test
@@ -165,16 +163,14 @@ public class ShortenLinkTest {
       )
     );
 
-    assertDoesNotThrow(() -> {
-      String body = client.toBlocking().retrieve(
-        HttpRequest.POST(
-          "/urls/shorten",
-          requestBody
-        ).header("token", TEST_VALID_TOKEN)
-      );
+    String body = client.toBlocking().retrieve(
+      HttpRequest.POST(
+        "/urls/shorten",
+        requestBody
+      ).header("token", TEST_VALID_TOKEN)
+    );
 
-      assertThat(body.contains("\"shortened_url\":\"http://localhost:8080/r/alias\"")).isEqualTo(true);
-    });
+    assertThat(body.contains("\"shortened_url\":\"http://localhost:8080/r/alias\"")).isEqualTo(true);
 
     // clear all links in 'links' directory
     // temporary solution before we configure our data storage properly

--- a/src/test/java/edu/kpi/testcourse/rest/ShortenLinkTest.java
+++ b/src/test/java/edu/kpi/testcourse/rest/ShortenLinkTest.java
@@ -8,6 +8,12 @@ import io.micronaut.http.client.HttpClient;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import io.micronaut.runtime.server.EmbeddedServer;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Comparator;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -168,6 +174,18 @@ public class ShortenLinkTest {
       );
 
       assertThat(body.contains("\"shortened_url\":\"http://localhost:8080/r/alias\"")).isEqualTo(true);
+    });
+
+    // clear all links in 'links' directory
+    // temporary solution before we configure our data storage properly
+    assertDoesNotThrow(() -> {
+      Path linksPath = Paths.get("data/links/");
+
+      try (Stream<Path> walk = Files.walk(linksPath)) {
+        walk.sorted(Comparator.reverseOrder())
+          .map(Path::toFile)
+          .forEach(File::delete);
+      }
     });
   }
 }

--- a/src/test/java/edu/kpi/testcourse/rest/ShortenLinkTest.java
+++ b/src/test/java/edu/kpi/testcourse/rest/ShortenLinkTest.java
@@ -52,6 +52,18 @@ public class ShortenLinkTest {
     if (client != null) {
       client.stop();
     }
+
+    // clear all links in 'links' directory
+    // temporary solution before we configure our data storage properly
+    assertDoesNotThrow(() -> {
+      Path linksPath = Paths.get("data/links/");
+
+      try (Stream<Path> walk = Files.walk(linksPath)) {
+        walk.sorted(Comparator.reverseOrder())
+          .map(Path::toFile)
+          .forEach(File::delete);
+      }
+    });
   }
 
   @Test
@@ -171,17 +183,5 @@ public class ShortenLinkTest {
     );
 
     assertThat(body.contains("\"shortened_url\":\"http://localhost:8080/r/alias\"")).isEqualTo(true);
-
-    // clear all links in 'links' directory
-    // temporary solution before we configure our data storage properly
-    assertDoesNotThrow(() -> {
-      Path linksPath = Paths.get("data/links/");
-
-      try (Stream<Path> walk = Files.walk(linksPath)) {
-        walk.sorted(Comparator.reverseOrder())
-          .map(Path::toFile)
-          .forEach(File::delete);
-      }
-    });
   }
 }


### PR DESCRIPTION
* Moved URL and authorization exceptions to separate categories
* Removed sample UsersException and UrlsException that are not used
* Moved short link to separate DTO
* Moved list of short links (for `GET /urls` controller) to separate DTO
* Store URL in the short link as a string: for easier validation and serialization (temporarily using Gson - must switch to Jackson in future)
* Renamed fiends in ShortLink DTO (to make serialized JSON correspond to the project specification)
* Own URL validation in `safelyCreateUrl` method of ShortLinkService

Still need a clean way to delete links and users after testing